### PR TITLE
To debug frontend end routing in gh pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,9 @@ import Blog from "./Blog";
 
 const App = () => {
   let url = process.env.PUBLIC_URL || '';
-  console.log(window.location.pathname);
+  // I beleive that process.env.PUBLIC_URL is useful in case of CRA as it exposes
+  // homepage URL of the APP through this env variable and so this hack need not
+  // be done
   if (window.location.pathname.includes(`profile`)) {
     url = '/profile'
   }

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -12,8 +12,9 @@ import Title from "../Title/Title";
 
 const Header = () => {
   let url = process.env.PUBLIC_URL || '';
-  console.log(url);
-  console.log(window.location.pathname);
+  // I beleive that process.env.PUBLIC_URL is useful in case of CRA as it exposes
+  // homepage URL of the APP through this env variable and so this hack need not
+  // be done
   if (window.location.pathname.includes(`profile`)) {
     url = '/profile'
   }


### PR DESCRIPTION
why:

* I was not able to use `process.env.PUBLIC_URL` which exposes `homepage` property in package.json to make routing work in GH pages
* This I think is becuase this app is not using create-react-app

How:

* added a hack to check whether the pathname indicates whether its a deployed URL and gave the route paths accordingly